### PR TITLE
Avoid duplicate parts SSTUBase_Interstage

### DIFF
--- a/GameData/ProceduralFairings/Parts/Adapters/SSTUBase.cfg
+++ b/GameData/ProceduralFairings/Parts/Adapters/SSTUBase.cfg
@@ -184,36 +184,3 @@ PART
 		}
 	}
 }
-
-+PART[SSTUBase]
-{
-    @name = SSTUBase_Interstage
-    @title = Procedural Hollow Truss Interstage Adapter
-    @description = Hollow Truss structural base for creating Interstages.
-
-    @MODULE[KzNodeNumberTweaker]
-    {
-        @numNodes = 4
-    }
-
-    !MODULE[KzFairingBaseResizer] {}
-
-    @MODULE[ModuleDecouple]
-    {
-        @menuName = Decouple Top Node
-    }
-
-    MODULE
-    {
-        name = ProceduralFairingAdapter
-        baseSize = 1.25
-        topSize = 1.25
-        height = 2.0
-        costPerTonne = 1000
-        specificMass = 0.006, 0.013, 0.010, 0
-        specificBreakingForce = 6050
-        specificBreakingTorque = 6050
-        dragAreaScale = 1.5
-        topNodeDecouplesWhenFairingsGone = False
-    }
-}

--- a/GameData/ProceduralFairings/Parts/Adapters/SSTUBase_Interstage.cfg
+++ b/GameData/ProceduralFairings/Parts/Adapters/SSTUBase_Interstage.cfg
@@ -188,36 +188,3 @@ PART
 		}
 	}
 }
-
-+PART[SSTUBase]
-{
-    @name = SSTUBase_Interstage
-    @title = Procedural Hollow Truss Interstage Adapter
-    @description = Hollow Truss structural base for creating Interstages.
-
-    @MODULE[KzNodeNumberTweaker]
-    {
-        @numNodes = 4
-    }
-
-    !MODULE[KzFairingBaseResizer] {}
-
-    @MODULE[ModuleDecouple]
-    {
-        @menuName = Decouple Top Node
-    }
-
-    MODULE
-    {
-        name = ProceduralFairingAdapter
-        baseSize = 1.25
-        topSize = 1.25
-        height = 2.0
-        costPerTonne = 1000
-        specificMass = 0.006, 0.013, 0.010, 0
-        specificBreakingForce = 6050
-        specificBreakingTorque = 6050
-        dragAreaScale = 1.5
-        topNodeDecouplesWhenFairingsGone = False
-    }
-}


### PR DESCRIPTION
As there already is a dedicated part config SSTUBase_Interstage.cfg the "+PART[SSTUBase]" in SSTUBase.cfg is no more needed.
And the SSTUBase_Interstage.cfg was a clone of SSTUBase.cfg as it seems, because the same "+PART[SSTUBase]" was in there. So a duplicate of a duplicate.