### PR TITLE
Fix model paths on uprade dummy parts

### DIFF
--- a/GameData/ProceduralFairings/PF_Settings.cfg
+++ b/GameData/ProceduralFairings/PF_Settings.cfg
@@ -48,7 +48,7 @@ PART
 
     MODEL
     {
-        model = ProceduralFairings/Parts/base_standard
+        model = ProceduralFairings/Assets/base_standard
     }
 
     TechRequired = miniaturization
@@ -68,7 +68,7 @@ PART
 
     MODEL
     {
-        model = ProceduralFairings/Parts/base_standard
+        model = ProceduralFairings/Assets/base_standard
     }
 
     TechRequired = specializedConstruction
@@ -88,7 +88,7 @@ PART
 
     MODEL
     {
-        model = ProceduralFairings/Parts/base_standard
+        model = ProceduralFairings/Assets/base_standard
     }
 
     TechRequired = advAerodynamics
@@ -110,7 +110,7 @@ PART
 
     MODEL
     {
-        model = ProceduralFairings/Parts/base_standard
+        model = ProceduralFairings/Assets/base_standard
     }
 
     TechRequired = heavyAerodynamics
@@ -130,7 +130,7 @@ PART
 
     MODEL
     {
-        model = ProceduralFairings/Parts/base_standard
+        model = ProceduralFairings/Assets/base_standard
     }
 
     TechRequired = experimentalAerodynamics
@@ -150,7 +150,7 @@ PART
 
     MODEL
     {
-        model = ProceduralFairings/Parts/thrust_plate
+        model = ProceduralFairings/Assets/thrust_plate
     }
 
     TechRequired = metaMaterials
@@ -170,7 +170,7 @@ PART
 
     MODEL
     {
-        model = ProceduralFairings/Parts/thrust_plate
+        model = ProceduralFairings/Assets/thrust_plate
     }
 
     TechRequired = aerospaceTech


### PR DESCRIPTION
This PR fixes the model paths for the dummy parts in PF_Settings.cfg, allowing them to show up again in the research tree