### PR TITLE
Fix netkan install property

### DIFF
--- a/ProceduralFairings.netkan
+++ b/ProceduralFairings.netkan
@@ -21,7 +21,7 @@
     ],
     "install" : [
         {
-            "file"          : "ProceduralFairings",
+            "find"          : "ProceduralFairings",
             "install_to"    : "GameData"
         }
     ]


### PR DESCRIPTION
Hi @NathanKell,

The release ZIP folder structure was changed to include GameData (possibly in #49?), and "file" only matches absolute paths from the root of the ZIP.