### PR TITLE
Cosmetic VAB workaround

### DIFF
--- a/GameData/ProceduralFairings/Parts/Payload/fairing_sides.cfg
+++ b/GameData/ProceduralFairings/Parts/Payload/fairing_sides.cfg
@@ -86,6 +86,7 @@ PART
 		revClampSpeed = false
 		revClampPercent = false
 		deployPercent = 50
+		instantAnimInEditor = false
 	}
 
     MODULE


### PR DESCRIPTION
ModuleAnimateGeneric clamps inconsistently at "instant" speed in the editor.