### PR TITLE
Rework fairing side auto-strut logic

### DIFF
--- a/Source/ProceduralFairings/FairingDecoupler.cs
+++ b/Source/ProceduralFairings/FairingDecoupler.cs
@@ -94,6 +94,10 @@ namespace Keramzit
             yield return new WaitForFixedUpdate();
             if (part.parent)
             {
+                if (part.parent.FindModuleImplementing<ProceduralFairingBase>() is ProceduralFairingBase fbase)
+                {
+                    fbase.OnFairingDecouple(part);
+                }
                 part.decouple();
                 ejectFx.audio.Play();
                 decoupled = true;


### PR DESCRIPTION
Removes the old code that added a joint between fairing sides and the fairing base payload. Now fairing sides are jointed to each other - from the tip of one fairing side to the transform (extreme bottom) of another.